### PR TITLE
LED Indicators

### DIFF
--- a/BasalDose/BasalDose.c
+++ b/BasalDose/BasalDose.c
@@ -85,8 +85,8 @@ void BasalDose_DoseInject(void)
 	
 	BasalDose_DoseTimingDisable(); // Disable Timer0
 	
-	LPC_GPIO1->FIOSET |= 1 << 28; // Turn P1.28 LED on to indicate
-								  // stepper motor is spinning
+	// Turn P1.28 LED on to indicate stepper motor is spinning (forward)
+	LPC_GPIO1->FIOSET |= 1 << 28; 
 								  
 	StepperMotor_StepForward(); // Call the stepper motor
 }
@@ -98,8 +98,8 @@ void BasalDose_RetractSyringe(void)
 	
 	BasalDose_DoseTimingDisable(); // Disable Timer0
 	
-	LPC_GPIO1->FIOSET |= 1 << 28; // Turn P1.28 LED on to indicate
-								  // stepper motor is spinning
+	// Turn P1.28 LED on to indicate stepper motor is spinning (backward)
+	LPC_GPIO1->FIOSET |= 1 << 28; 
 								  
 	StepperMotor_StepBackward(); // Call stepper motor
 }
@@ -110,9 +110,10 @@ void TIMER0_IRQHandler(void)
 	if((LPC_TIM0->IR & 0x01) == 0x01) // If MR0 interrupt
 	{
 		Control_DosageAmount(BASAL_STEPS); // Calculate the number of steps
-		LPC_GPIO1->FIOSET |= 1 << 29; // Turn P1.29 LED on to indicate that 
-									  // the basal dose is being administered
-									  
+		
+		// Turn P1.29 LED on to indicate that the basal dose is being administered
+		LPC_GPIO1->FIOSET |= 1 << 29; 
+									  						  
 		BasalDose_DoseEnable(); // Enables Timer1
 	}
 }

--- a/BasalDose/BasalDose.c
+++ b/BasalDose/BasalDose.c
@@ -101,7 +101,7 @@ void BasalDose_RetractSyringe(void)
 	// Turn P1.28 LED on to indicate stepper motor is spinning (backward)
 	LPC_GPIO1->FIOSET |= 1 << 28;
 	
-	/*
+	/**
 	 * I have retract currently as the same LED as going forward,
 	 * could easily change to another LED
 	 */

--- a/BasalDose/BasalDose.c
+++ b/BasalDose/BasalDose.c
@@ -86,8 +86,8 @@ void BasalDose_DoseInject(void)
 	BasalDose_DoseTimingDisable(); // Disable Timer0
 	
 	// Turn P1.28 LED on to indicate stepper motor is spinning (forward)
-	LPC_GPIO1->FIOSET |= 1 << 28; 
-								  
+	LPC_GPIO1->FIOSET |= 1 << 28;
+	
 	StepperMotor_StepForward(); // Call the stepper motor
 }
 
@@ -99,8 +99,14 @@ void BasalDose_RetractSyringe(void)
 	BasalDose_DoseTimingDisable(); // Disable Timer0
 	
 	// Turn P1.28 LED on to indicate stepper motor is spinning (backward)
-	LPC_GPIO1->FIOSET |= 1 << 28; 
-								  
+	LPC_GPIO1->FIOSET |= 1 << 28;
+	
+	/*
+	 * I have retract currently as the same LED as going forward,
+	 * could easily change to another LED
+	 */
+	LPC_GPIO1->FIOSET |= 1 << 29; 
+	
 	StepperMotor_StepBackward(); // Call stepper motor
 }
 
@@ -112,8 +118,8 @@ void TIMER0_IRQHandler(void)
 		Control_DosageAmount(BASAL_STEPS); // Calculate the number of steps
 		
 		// Turn P1.29 LED on to indicate that the basal dose is being administered
-		LPC_GPIO1->FIOSET |= 1 << 29; 
-									  						  
+		LPC_GPIO1->FIOSET |= 1 << 29;
+		
 		BasalDose_DoseEnable(); // Enables Timer1
 	}
 }
@@ -131,6 +137,9 @@ void TIMER1_IRQHandler(void)
 		}
 		else
 		{
+			// If the syringe empty, clear out bolus LED if it is being adminsitered
+			LPC_GPIO1->FIOCLR |= 1 << 31; 
+			
 			if(StepperMotor_GlobalPosition <= SYRINGE_LENGTH)
 				StepperMotor_GlobalPosition += SYRINGE_LENGTH;
 			BasalDose_RetractSyringe(); // Call the stepper motor backward

--- a/BasalDose/BasalDose.c
+++ b/BasalDose/BasalDose.c
@@ -54,7 +54,6 @@ void BasalDose_DoseTimingDisable(void)
 void BasalDose_DoseEnable(void)
 {
 	LPC_TIM0->IR |= 1 << 0; // Clear MR0 interrupt flag
-	LPC_GPIO1->FIOPIN ^= 1 << 29; // Toggle the LED
 
 	NVIC_EnableIRQ(TIMER1_IRQn); // Enable Timer1 IRQ
 }
@@ -83,10 +82,11 @@ void BasalDose_DoseAmountInitiate(void)
 void BasalDose_DoseInject(void)
 {
 	LPC_TIM1->IR |= 1 << 0; // Clear MR0 interrupt flag
-	LPC_GPIO1->FIOPIN ^= 1 << 28; // Toggle the LED
+	//LPC_GPIO1->FIOPIN ^= 1 << 28; // Toggle the LED
 	
 	BasalDose_DoseTimingDisable(); // Disable Timer0
 	
+	LPC_GPIO1->FIOSET |= 1 << 28;
 	StepperMotor_StepForward(); // Call the stepper motor
 }
 
@@ -94,10 +94,11 @@ void BasalDose_DoseInject(void)
 void BasalDose_RetractSyringe(void)
 {
 	LPC_TIM1->IR |= 1 << 0; // Clear MR0 interrupt flag
-	LPC_GPIO1->FIOPIN ^= 1 << 28; // Toggle the LED
+	//LPC_GPIO1->FIOPIN ^= 1 << 28; // Toggle the LED
 	
 	BasalDose_DoseTimingDisable(); // Disable Timer0
 	
+	LPC_GPIO1->FIOSET |= 1 << 28;
 	StepperMotor_StepBackward(); // Call stepper motor
 }
 
@@ -107,7 +108,7 @@ void TIMER0_IRQHandler(void)
 	if((LPC_TIM0->IR & 0x01) == 0x01) // If MR0 interrupt
 	{
 		Control_DosageAmount(BASAL_STEPS); // Calculate the number of steps
-		
+		LPC_GPIO1->FIOSET |= 1 << 29; // Toggle the LED
 		BasalDose_DoseEnable(); // Enables Timer1
 	}
 }

--- a/BasalDose/BasalDose.c
+++ b/BasalDose/BasalDose.c
@@ -82,11 +82,12 @@ void BasalDose_DoseAmountInitiate(void)
 void BasalDose_DoseInject(void)
 {
 	LPC_TIM1->IR |= 1 << 0; // Clear MR0 interrupt flag
-	//LPC_GPIO1->FIOPIN ^= 1 << 28; // Toggle the LED
 	
 	BasalDose_DoseTimingDisable(); // Disable Timer0
 	
-	LPC_GPIO1->FIOSET |= 1 << 28;
+	LPC_GPIO1->FIOSET |= 1 << 28; // Turn P1.28 LED on to indicate
+								  // stepper motor is spinning
+								  
 	StepperMotor_StepForward(); // Call the stepper motor
 }
 
@@ -94,11 +95,12 @@ void BasalDose_DoseInject(void)
 void BasalDose_RetractSyringe(void)
 {
 	LPC_TIM1->IR |= 1 << 0; // Clear MR0 interrupt flag
-	//LPC_GPIO1->FIOPIN ^= 1 << 28; // Toggle the LED
 	
 	BasalDose_DoseTimingDisable(); // Disable Timer0
 	
-	LPC_GPIO1->FIOSET |= 1 << 28;
+	LPC_GPIO1->FIOSET |= 1 << 28; // Turn P1.28 LED on to indicate
+								  // stepper motor is spinning
+								  
 	StepperMotor_StepBackward(); // Call stepper motor
 }
 
@@ -108,7 +110,9 @@ void TIMER0_IRQHandler(void)
 	if((LPC_TIM0->IR & 0x01) == 0x01) // If MR0 interrupt
 	{
 		Control_DosageAmount(BASAL_STEPS); // Calculate the number of steps
-		LPC_GPIO1->FIOSET |= 1 << 29; // Toggle the LED
+		LPC_GPIO1->FIOSET |= 1 << 29; // Turn P1.29 LED on to indicate that 
+									  // the basal dose is being administered
+									  
 		BasalDose_DoseEnable(); // Enables Timer1
 	}
 }

--- a/BolusDose/BolusDose.c
+++ b/BolusDose/BolusDose.c
@@ -27,7 +27,8 @@ void BolusDose_DoseInitiate(void)
 void EINT3_IRQHandler(void)
 {
 	LPC_GPIOINT->IO2IntClr |= (1<<10); // Clear the status
-	LPC_GPIO1->FIOSET |= 1 << 31; // Toggle the LED
+	LPC_GPIO1->FIOSET |= 1 << 31; // Turn P1.31 LED on to indicate that 
+								  // the bolus dose is being administered
 	
 	Control_DosageAmount(BOLUS_STEPS); // Calculate the number of steps
 	

--- a/BolusDose/BolusDose.c
+++ b/BolusDose/BolusDose.c
@@ -27,7 +27,7 @@ void BolusDose_DoseInitiate(void)
 void EINT3_IRQHandler(void)
 {
 	LPC_GPIOINT->IO2IntClr |= (1<<10); // Clear the status
-	LPC_GPIO1->FIOPIN ^= 1 << 31; // Toggle the LED
+	LPC_GPIO1->FIOSET |= 1 << 31; // Toggle the LED
 	
 	Control_DosageAmount(BOLUS_STEPS); // Calculate the number of steps
 	

--- a/BolusDose/BolusDose.c
+++ b/BolusDose/BolusDose.c
@@ -27,8 +27,9 @@ void BolusDose_DoseInitiate(void)
 void EINT3_IRQHandler(void)
 {
 	LPC_GPIOINT->IO2IntClr |= (1<<10); // Clear the status
-	LPC_GPIO1->FIOSET |= 1 << 31; // Turn P1.31 LED on to indicate that 
-								  // the bolus dose is being administered
+	
+	// Turn P1.31 LED on to indicate that the bolus dose is being administered
+	LPC_GPIO1->FIOSET |= 1 << 31; 
 	
 	Control_DosageAmount(BOLUS_STEPS); // Calculate the number of steps
 	

--- a/StepperMotor/StepperMotor.c
+++ b/StepperMotor/StepperMotor.c
@@ -76,9 +76,17 @@ void StepperMotor_StepForward(void)
 	// Compare if the amount injecfted is more than amount that is able to be recieved
 	if(BasalDose_DoseAmountCounter >= Control_AmountPerDose)
 	{
+		/* 
+		 * Turn off P1.28, P1.29, P1.30 LEDs to indicate that dosing the is now over
+     	 * GPIO1 P1.28 indicates motor rotation
+		 * GPIO1 P1.29 indicates basal dose rotation
+		 * GPIO1 P1.31 indicates bolus dose rotation
+		 */
+		 
 		LPC_GPIO1->FIOCLR |= 1 << 28;
 		LPC_GPIO1->FIOCLR |= 1 << 29;
 		LPC_GPIO1->FIOCLR |= 1 << 31;
+		
 		BasalDose_DoseDisable(); // Disable Timer1 IRQ
 		BasalDose_DoseTimingEnable(); // Enable Timer0
 		BasalDose_DoseAmountCounter = 0; // Set to 0

--- a/StepperMotor/StepperMotor.c
+++ b/StepperMotor/StepperMotor.c
@@ -76,6 +76,9 @@ void StepperMotor_StepForward(void)
 	// Compare if the amount injecfted is more than amount that is able to be recieved
 	if(BasalDose_DoseAmountCounter >= Control_AmountPerDose)
 	{
+		LPC_GPIO1->FIOCLR |= 1 << 28;
+		LPC_GPIO1->FIOCLR |= 1 << 29;
+		LPC_GPIO1->FIOCLR |= 1 << 31;
 		BasalDose_DoseDisable(); // Disable Timer1 IRQ
 		BasalDose_DoseTimingEnable(); // Enable Timer0
 		BasalDose_DoseAmountCounter = 0; // Set to 0

--- a/StepperMotor/StepperMotor.c
+++ b/StepperMotor/StepperMotor.c
@@ -137,6 +137,17 @@ void StepperMotor_StepBackward(void)
 	
 	if(StepperMotor_GlobalPosition <= SYRINGE_LENGTH)
 	{
+		/* 
+		 * Turn off P1.28, P1.29, P1.30 LEDs to indicate that dosing the is now over
+		 * GPIO1 P1.28 indicates stepper motor rotation
+		 * GPIO1 P1.29 indicates basal dose rotation
+		 * GPIO1 P1.31 indicates bolus dose rotation
+		 */
+		 
+		LPC_GPIO1->FIOCLR |= 1 << 28;
+		LPC_GPIO1->FIOCLR |= 1 << 29;
+		LPC_GPIO1->FIOCLR |= 1 << 31;
+		
 		StepperMotor_GlobalPosition = 0;
 		BasalDose_DoseDisable(); // Disable Timer1 IRQ
 		BasalDose_DoseTimingEnable(); // Enable Timer0 IRQ

--- a/StepperMotor/StepperMotor.c
+++ b/StepperMotor/StepperMotor.c
@@ -78,7 +78,7 @@ void StepperMotor_StepForward(void)
 	{
 		/* 
 		 * Turn off P1.28, P1.29, P1.30 LEDs to indicate that dosing the is now over
-     	 * GPIO1 P1.28 indicates motor rotation
+		 * GPIO1 P1.28 indicates motor rotation
 		 * GPIO1 P1.29 indicates basal dose rotation
 		 * GPIO1 P1.31 indicates bolus dose rotation
 		 */

--- a/StepperMotor/StepperMotor.c
+++ b/StepperMotor/StepperMotor.c
@@ -76,8 +76,8 @@ void StepperMotor_StepForward(void)
 	// Compare if the amount injecfted is more than amount that is able to be recieved
 	if(BasalDose_DoseAmountCounter >= Control_AmountPerDose)
 	{
-		/* 
-		 * Turn off P1.28, P1.29, P1.30 LEDs to indicate that dosing the is now over
+		/**
+		 * Turn off P1.28, P1.29, P1.30 LEDs to indicate that dosing is now over
 		 * GPIO1 P1.28 indicates stepper motor rotation
 		 * GPIO1 P1.29 indicates basal dose rotation
 		 * GPIO1 P1.31 indicates bolus dose rotation
@@ -137,8 +137,8 @@ void StepperMotor_StepBackward(void)
 	
 	if(StepperMotor_GlobalPosition <= SYRINGE_LENGTH)
 	{
-		/* 
-		 * Turn off P1.28, P1.29, P1.30 LEDs to indicate that dosing the is now over
+		/**
+		 * Turn off P1.28, P1.29, P1.30 LEDs to indicate that retraction is now over
 		 * GPIO1 P1.28 indicates stepper motor rotation
 		 * GPIO1 P1.29 indicates basal dose rotation
 		 * GPIO1 P1.31 indicates bolus dose rotation

--- a/StepperMotor/StepperMotor.c
+++ b/StepperMotor/StepperMotor.c
@@ -78,7 +78,7 @@ void StepperMotor_StepForward(void)
 	{
 		/* 
 		 * Turn off P1.28, P1.29, P1.30 LEDs to indicate that dosing the is now over
-		 * GPIO1 P1.28 indicates motor rotation
+		 * GPIO1 P1.28 indicates stepper motor rotation
 		 * GPIO1 P1.29 indicates basal dose rotation
 		 * GPIO1 P1.31 indicates bolus dose rotation
 		 */


### PR DESCRIPTION
LEDs to turn on and off instead of flickering when called. Also added special cases for when bolus is being administered and the syringe goes empty. Take a look and see what you guys think. I think we could definitely look into using a different LED to indicate that the motor is spinning backward instead of using the same one as basal administration.
